### PR TITLE
Tweak conversion mechanics to be more explicit and safe.

### DIFF
--- a/src/currency.rs
+++ b/src/currency.rs
@@ -2,7 +2,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Currency {
-    // The ISO 4217 currency code of the currency (eg. USD).
+    // The ISO 4217 (if applicable) currency code (eg. "USD"). For cryptocurrencies, this will  be a ticker
+    // symbol, such as BTC for Bitcoin.
     pub code: String,
 
     // The full display name of the currency (eg. US Dollars).
@@ -13,7 +14,7 @@ pub struct Currency {
 
     // The estimated millisatoshis per smallest "unit" of this currency (eg. 1 cent in USD).
     #[serde(rename = "multiplier")]
-    pub millisatoshi_per_unit: i64,
+    pub millisatoshi_per_unit: f64,
 
     // The minimum amount of the currency that can be sent in a single transaction. This is in the
     // smallest unit of the currency (eg. cents for USD).
@@ -25,10 +26,12 @@ pub struct Currency {
     #[serde(rename = "maxSendable")]
     pub max_sendable: i64,
 
-    // The number of digits after the decimal point for display on the sender side. For example,
-    // in USD, by convention, there are 2 digits for cents - $5.95. in this case, `decimals`
-    // would be 2. Note that the multiplier is still always in the smallest unit (cents). This field
-    // is only for display purposes. The sender should assume zero if this field is omitted, unless
-    // they know the proper display format of the target currency.
-    pub decimals: Option<i64>,
+    // The number of digits after the decimal point for display on the sender side, and to add clarity
+    // around what the "smallest unit" of the currency is. For example, in USD, by convention, there are 2 digits for
+    // cents - $5.95. In this case, `decimals` would be 2. Note that the multiplier is still always in the smallest
+    // unit (cents). In addition to display purposes, this field can be used to resolve ambiguity in what the multiplier
+    // means. For example, if the currency is "BTC" and the multiplier is 1000, really we're exchanging in SATs, so
+    // `decimals` would be 8.
+    // For details on edge cases and examples, see https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md.
+    pub decimals: i64,
 }

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Currency {
     // The ISO 4217 (if applicable) currency code (eg. "USD"). For cryptocurrencies, this will  be a ticker
     // symbol, such as BTC for Bitcoin.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -98,7 +98,7 @@ impl LnurlpRequest {
 
 /// LnurlpResponse is the response to the LnurlpRequest.
 /// It is sent by the VASP that is receiving the payment to provide information to the sender about the receiver.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct LnurlpResponse {
     pub tag: String,
     pub callback: String,

--- a/src/uma_test.rs
+++ b/src/uma_test.rs
@@ -24,7 +24,7 @@ mod tests {
             uma_version: "0.2".to_string(),
         };
 
-        let url_string = format!("https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true&timestamp={}",&timestamp);
+        let url_string = format!("https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.2&isSubjectToTravelRule=true&timestamp={}", &timestamp);
         let url = url::Url::parse(&url_string).unwrap();
 
         let query = parse_lnurlp_request(&url).unwrap();
@@ -96,7 +96,7 @@ mod tests {
             true,
             None,
         )
-        .unwrap();
+            .unwrap();
 
         let query = parse_lnurlp_request(&query_url).unwrap();
 
@@ -115,7 +115,7 @@ mod tests {
             true,
             None,
         )
-        .unwrap();
+            .unwrap();
 
         let query = parse_lnurlp_request(&query_url).unwrap();
 
@@ -136,7 +136,7 @@ mod tests {
             true,
             None,
         )
-        .unwrap();
+            .unwrap();
         let query = parse_lnurlp_request(&request).unwrap();
 
         let metadata = create_metadata_for_bob().unwrap();
@@ -167,7 +167,7 @@ mod tests {
             &currency_options,
             crate::kyc_status::KycStatus::KycStatusVerified,
         )
-        .unwrap();
+            .unwrap();
 
         let response_json = serde_json::to_vec(&response).unwrap();
         let response = parse_lnurlp_response(&response_json).unwrap();
@@ -196,7 +196,7 @@ mod tests {
             None,
             "/api/lnurl/utxocallback?txid=1234",
         )
-        .unwrap();
+            .unwrap();
 
         let payreq_json = serde_json::to_vec(&payreq).unwrap();
 
@@ -212,7 +212,7 @@ mod tests {
                 .encrypted_travel_rule_info
                 .unwrap(),
         )
-        .unwrap();
+            .unwrap();
         let plain_text = ecies::decrypt(&sk1.serialize(), &cipher_text).unwrap();
         assert_eq!(plain_text, b"some TR info for VASP2");
     }
@@ -237,7 +237,7 @@ mod tests {
             None,
             "/api/lnurl/utxocallback?txid=1234",
         )
-        .unwrap();
+            .unwrap();
 
         let client = FakeInvoiceCreator {};
 
@@ -254,7 +254,7 @@ mod tests {
             None,
             "/api/lnurl/utxocallback?txid=1234",
         )
-        .unwrap();
+            .unwrap();
 
         let response_json = serde_json::to_vec(&response).unwrap();
 

--- a/src/uma_test.rs
+++ b/src/uma_test.rs
@@ -96,7 +96,7 @@ mod tests {
             true,
             None,
         )
-            .unwrap();
+        .unwrap();
 
         let query = parse_lnurlp_request(&query_url).unwrap();
 
@@ -115,7 +115,7 @@ mod tests {
             true,
             None,
         )
-            .unwrap();
+        .unwrap();
 
         let query = parse_lnurlp_request(&query_url).unwrap();
 
@@ -136,7 +136,7 @@ mod tests {
             true,
             None,
         )
-            .unwrap();
+        .unwrap();
         let query = parse_lnurlp_request(&request).unwrap();
 
         let metadata = create_metadata_for_bob().unwrap();
@@ -167,7 +167,7 @@ mod tests {
             &currency_options,
             crate::kyc_status::KycStatus::KycStatusVerified,
         )
-            .unwrap();
+        .unwrap();
 
         let response_json = serde_json::to_vec(&response).unwrap();
         let response = parse_lnurlp_response(&response_json).unwrap();
@@ -196,7 +196,7 @@ mod tests {
             None,
             "/api/lnurl/utxocallback?txid=1234",
         )
-            .unwrap();
+        .unwrap();
 
         let payreq_json = serde_json::to_vec(&payreq).unwrap();
 
@@ -212,7 +212,7 @@ mod tests {
                 .encrypted_travel_rule_info
                 .unwrap(),
         )
-            .unwrap();
+        .unwrap();
         let plain_text = ecies::decrypt(&sk1.serialize(), &cipher_text).unwrap();
         assert_eq!(plain_text, b"some TR info for VASP2");
     }
@@ -237,7 +237,7 @@ mod tests {
             None,
             "/api/lnurl/utxocallback?txid=1234",
         )
-            .unwrap();
+        .unwrap();
 
         let client = FakeInvoiceCreator {};
 
@@ -254,7 +254,7 @@ mod tests {
             None,
             "/api/lnurl/utxocallback?txid=1234",
         )
-            .unwrap();
+        .unwrap();
 
         let response_json = serde_json::to_vec(&response).unwrap();
 

--- a/src/uma_test.rs
+++ b/src/uma_test.rs
@@ -21,7 +21,7 @@ mod tests {
             is_subject_to_travel_rule: true,
             vasp_domain: "vasp1.com".to_string(),
             timestamp,
-            uma_version: "0.1".to_string(),
+            uma_version: "0.2".to_string(),
         };
 
         let url_string = format!("https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true&timestamp={}",&timestamp);
@@ -145,10 +145,10 @@ mod tests {
             code: "USD".to_string(),
             name: "US Doller".to_string(),
             symbol: "$".to_string(),
-            millisatoshi_per_unit: 34150,
+            millisatoshi_per_unit: 34150.0,
             min_sendable: 1,
             max_sendable: 10000000,
-            decimals: Some(2),
+            decimals: 2,
         }];
 
         let response = get_lnurlp_response(

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,7 +1,7 @@
 use crate::uma;
 
 const MAJOR_VERSION: i32 = 0;
-const MINOR_VERSION: i32 = 1;
+const MINOR_VERSION: i32 = 2;
 
 pub fn uma_protocol_version() -> String {
     format!("{}.{}", MAJOR_VERSION, MINOR_VERSION)


### PR DESCRIPTION
- Make the decimals field on `Currency` required and change its description to include more details about its use.
- Change the multiplier field from i64 to f64 to allow for very small unit currencies. See https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md for details on why this is needed.

NOTE: This is technically a breaking change. Given that we're not yet at UMA 1.0, I'm bumping the protocol version here to 0.2 to indicate the bump and to be able to tell what version the counterparty is using for debugging.